### PR TITLE
Dispatch and gitsupport

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,7 +65,7 @@ m4_ifndef([PKG_CHECK_MODULES],
 
 m4_ifndef([SHTK_CHECK],
     [m4_fatal([Cannot find shtk.m4; see the INSTALL document for help])])
-SHTK_CHECK([>= 1.7])
+SHTK_CHECK([>= 1.7.1])
 
 
 AC_PATH_PROG([KYUA], [kyua])

--- a/sysbuild.1.in
+++ b/sysbuild.1.in
@@ -70,6 +70,8 @@ now.
 .Nm
 can be seen as a simple wrapper over
 .Xr cvs 1
+or
+.Xr git 1
 and the
 .Nm build.sh
 script that ships with the
@@ -261,12 +263,18 @@ The fetch command downloads or updates the
 .Nx
 source trees, which include src and, optionally, xsrc.
 .Pp
+The method used to fetch the source is either git or cvs and it
+is choosen using
+.Va FETCH_METHOD
+, it is cvs by default.
 If the modules do not exist yet in the locations specified by
 .Va SRCDIR
 and
 .Va XSRCDIR ,
 this performs an initial CVS checkout of the trees.
 If the modules exist, this performs a CVS update.
+If using git, repositories must have been cloned and switched to the
+desired branch as sysbuild only performs a pull.
 .Pp
 The
 .Va CVSROOT

--- a/sysbuild.1.in
+++ b/sysbuild.1.in
@@ -167,7 +167,11 @@ For every machine type listed in
 issues a
 .Nm build.sh
 call for that particular machine using the rest of the settings defined in
-the configuration file.
+the configuration file. Each
+.Nm build.sh
+call produces
+.Pa ${BUILD_ROOT}/${MACHINE}/build.log
+and sysbuild echoes build SUCESS or FAILURE on its output for each machine.
 The targets passed to the
 .Nm build.sh
 script are those defined in the

--- a/sysbuild.conf.5
+++ b/sysbuild.conf.5
@@ -52,8 +52,14 @@ Default:
 CVS tag to use during checkouts or updates of the src and xsrc modules.
 .Pp
 Default: not defined.
+.It Va FETCH_METHOD
+Method used to fetch sources, either git or cvs. If git then both variables above
+are not used.
+.Pp
+Default:
+.Sq cvs
 .It Va SRCDIR
-Path to the src module.
+Path to the src module or local git repository.
 If you want
 .Xr sysbuild 1
 to perform an update of this directory before every build, you will need
@@ -68,7 +74,7 @@ Whether to perform an update of the source tree before every build or not.
 Default:
 .Sq true .
 .It Va XSRCDIR
-Path to the xsrc module.
+Path to the xsrc module or local git repository.
 If you want
 .Xr sysbuild 1
 to perform an update of this directory before every build, you will need

--- a/sysbuild.sh
+++ b/sysbuild.sh
@@ -183,7 +183,7 @@ do_one_build() {
 
     if [ $? -eq 0 -a "$(shtk_config_get FETCH_METHOD)" = "git" ]; then
         echo "$(shtk_git_gethash $(shtk_config_get SRCDIR))" >"${basedir}/.srchash_last_successful_build"
-        if shtk_config_hash XSRCDIR; then
+        if shtk_config_has XSRCDIR; then
             echo "$(shtk_git_gethash $(shtk_config_get XSRCDIR))" >"${basedir}/.xsrchash_last_successful_build"
         fi
     fi

--- a/sysbuild.sh
+++ b/sysbuild.sh
@@ -137,6 +137,8 @@ do_one_build() {
         esac
     done
 
+    mkdir -p "${basedir}"
+
     ( cd "$(shtk_config_get SRCDIR)" && shtk_process_run ./build.sh \
         -D"${basedir}/destdir" \
         -M"${basedir}/obj" \
@@ -150,7 +152,7 @@ do_one_build() {
         -m"${machine}" \
         ${uflag} \
         ${xflag} \
-        ${targets} )
+        ${targets} >"${basedir}/build.log" 2>&1 )
 }
 
 
@@ -206,7 +208,8 @@ sysbuild_build() {
 
     shtk_config_run_hook pre_build_hook
     for machine in ${machines}; do
-        do_one_build "${machine}"
+        printf "Build ${machine}...\n"
+        do_one_build "${machine}" && printf "SUCCESS\n" || printf "FAIL\n"
     done
     shtk_config_run_hook post_build_hook
 }

--- a/sysbuild_test.sh
+++ b/sysbuild_test.sh
@@ -668,6 +668,7 @@ BUILD_ROOT = ${HOME}/sysbuild
 BUILD_TARGETS = release
 CVSROOT = :ext:anoncvs@anoncvs.NetBSD.org:/cvsroot
 CVSTAG is undefined
+FETCH_METHOD = cvs
 INCREMENTAL_BUILD = false
 MACHINES = $(uname -m)
 MKVARS is undefined
@@ -753,6 +754,7 @@ BUILD_ROOT = /tmp/test
 BUILD_TARGETS = release
 CVSROOT = foo bar
 CVSTAG = the-new-tag
+FETCH_METHOD = cvs
 INCREMENTAL_BUILD = false
 MACHINES = $(uname -m)
 MKVARS is undefined


### PR DESCRIPTION
Hello,

I hope that is not too rude to request like that.

Hopefully there is no functional change to existing configurations.

1. build.sh log goes to ${BUILD_ROOT}/${machine}/build.log, it is no more echoed by sysbuild
2. new variable FETCH_METHOD set to either git or cvs (by default) to enable (already user cloned) repository to be pulled by sysbuild
3. using git commit hash, sysbuild nows what was the commit when he last successfully built a particular platform for a particular conf and if source didnt' not changed, it does not try to build. I don't know how to do that with cvs..

conf files are for different branches or cvstags.

What do you think?