### PR TITLE
Support machine-arch pairs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,6 +24,10 @@ STILL UNDER DEVELOPMENT; NOT RELEASED YET.
 
 * Fixed option parsing to detect missing arguments to options.
 
+* Added support to build specific architectures within a machine type.
+  This is done via new syntax in the MACHINE variable, which can now
+  take pairs like evbarm-aarch64.
+
 
 Changes in version 2.7
 ======================

--- a/sysbuild.conf.5
+++ b/sysbuild.conf.5
@@ -25,7 +25,7 @@
 .\" THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 .\" OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.Dd February 6, 2017
+.Dd December 31, 2024
 .Dt SYSBUILD.CONF 5
 .Os
 .Sh NAME
@@ -133,6 +133,12 @@ Default:
 .Sq false .
 .It Va MACHINES
 Whitespace-separated list of machine types to build for.
+.Pp
+Every entry in this list can be a simple machine name like
+.Sq amd64
+or it can be a pair of the form
+.Sq evbarm-aarch64
+to indicate the architecture to target for a particular machine type.
 .Pp
 Default: the name of the host machine type.
 .It Va MKVARS

--- a/sysbuild.sh
+++ b/sysbuild.sh
@@ -78,11 +78,24 @@ sysbuild_set_defaults() {
 
 # Performs a build for a single machine type.
 #
-# \param machine The type of the machine to build for.
+# \param machine_pair The type of the machine to build for. Can optionally
+#    contain the architecture in the "machine-arch" form.
 do_one_build() {
-    local machine="${1}"; shift
+    local machine_pair="${1}"; shift
 
-    local basedir="$(shtk_config_get BUILD_ROOT)/${machine}"
+    local aflag=
+    local mflag=
+    case "${machine_pair}" in
+        *-*)
+            mflag="-m${machine_pair%%-*}" # First word in pair.
+            aflag="-a${machine_pair#*-}" # Other words in pair.
+            ;;
+        *)
+            mflag="-m${machine_pair}"
+            ;;
+    esac
+
+    local basedir="$(shtk_config_get BUILD_ROOT)/${machine_pair}"
 
     local njobs="$(shtk_config_get NJOBS)"
     local jflag=
@@ -147,7 +160,8 @@ do_one_build() {
         ${Vflags} \
         ${Xflag} \
         ${jflag} \
-        -m"${machine}" \
+        ${aflag} \
+        ${mflag} \
         ${uflag} \
         ${xflag} \
         ${targets} )


### PR DESCRIPTION
Extend the MACHINES syntax so that we can specify architecture types within a machine type such as evbarm-aarch64.